### PR TITLE
fix syntax of CUDA_VISIBLE_DEVICES

### DIFF
--- a/mpibind.c
+++ b/mpibind.c
@@ -617,7 +617,7 @@ static char *get_gpustring( int32_t gpus, int32_t numas, uint32_t *numagroup )
                     if( j==0 ){
                         asprintf(&str,"%d",gpus_in_numa[mapped_numa][j]);
                     }else{
-                        asprintf(&str,"%s %d",str, gpus_in_numa[mapped_numa][j]);
+                        asprintf(&str,"%s,%d",str, gpus_in_numa[mapped_numa][j]);
                     }
                 }
            }


### PR DESCRIPTION
In mpibind, I had the syntax wrong for CUDA_VISIBLE_DEVICES for the case where multiple GPUs are being assigned to one task.